### PR TITLE
bump pysam up to 0.10.0

### DIFF
--- a/clrsvsim/test_simulator.py
+++ b/clrsvsim/test_simulator.py
@@ -6,7 +6,7 @@ from cigar import Cigar
 from mock import Mock
 from pyfasta import Fasta
 
-from simulator import (
+from clrsvsim.simulator import (
     make_split_read,
     modify_read,
     modify_read_for_insertion,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ nose==1.3.7
 numpy==1.10.1
 preconditions==0.1
 pyfasta==0.5.2
-pysam==0.9.0
+pysam==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 
 setup(name = "clrsvsim",
-      version = "0.0.1",
+      version = "0.0.2",
       description = "Color Genomics Structural Variant Simulator",
       author = "Color Genomics",
       author_email = "dev@color.com",
@@ -20,7 +20,7 @@ setup(name = "clrsvsim",
         'numpy==1.10.1',
         'preconditions==0.1',
         'pyfasta==0.5.2',
-        'pysam==0.9.0',
+        'pysam==0.10.0',
       ],
       license = "Apache-2.0",
 )


### PR DESCRIPTION
...to match our current constraints.lock.

hey @giladmishne, i currently get these test failures, with both pysam 0.9.0 and 0.10.0. so i guess that means it's ok, since it at least doesn't regress anything? let me know if i should try something else!

```
======================================================================
ERROR: test_invert_read (clrsvsim.test_simulator.SplitReadTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ryan/color/clrsvsim/clrsvsim/test_simulator.py", line 215, in test_invert_read
    assert_inversion(read, start, start + len(sequence), sequence, expected_seq, expected_cigar)
  File "/Users/ryan/color/clrsvsim/clrsvsim/test_simulator.py", line 161, in assert_inversion
    inv, _ = invert_read(read, start, end, sequence, 0, 0)
  File "/Users/ryan/color/clrsvsim/clrsvsim/simulator.py", line 485, in invert_read
    read_with_inversion = make_split_read(read_with_inversion, breakpoint, clip_left=True, sequence=sequence)
  File "/Users/ryan/color/clrsvsim/local3/lib/python3.6/site-packages/preconditions.py", line 78, in g
    return f(*a, **kw)
  File "/Users/ryan/color/clrsvsim/clrsvsim/simulator.py", line 144, in make_split_read
    qual += DEFAULT_QUAL * (len(split_seq) - len(qual))
TypeError: object of type 'Mock' has no len()

======================================================================
ERROR: test_make_split_read (clrsvsim.test_simulator.SplitReadTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ryan/color/clrsvsim/clrsvsim/test_simulator.py", line 34, in test_make_split_read
    split_read = make_split_read(read, 5, True, sequence=alternate_seq)
  File "/Users/ryan/color/clrsvsim/local3/lib/python3.6/site-packages/preconditions.py", line 78, in g
    return f(*a, **kw)
  File "/Users/ryan/color/clrsvsim/clrsvsim/simulator.py", line 144, in make_split_read
    qual += DEFAULT_QUAL * (len(split_seq) - len(qual))
TypeError: object of type 'Mock' has no len()

======================================================================
ERROR: test_modify_read_for_insertion (clrsvsim.test_simulator.SplitReadTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ryan/color/clrsvsim/clrsvsim/test_simulator.py", line 101, in test_modify_read_for_insertion
    modified, changes = modify_read_for_insertion(read, ins_position, ins_seq, 0, 0)
  File "/Users/ryan/color/clrsvsim/clrsvsim/simulator.py", line 392, in modify_read_for_insertion
    read = make_split_read(read, breakpoint, clip_left, sequence=sequence)
  File "/Users/ryan/color/clrsvsim/local3/lib/python3.6/site-packages/preconditions.py", line 78, in g
    return f(*a, **kw)
  File "/Users/ryan/color/clrsvsim/clrsvsim/simulator.py", line 139, in make_split_read
    split_seq[:breakpoint] = sequence[-breakpoint:]
TypeError: slice indices must be integers or None or have an __index__ method

----------------------------------------------------------------------
Ran 9 tests in 0.057s

FAILED (errors=3)
```