### PR TITLE
Unpin dependencies, instead requiring a minimum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,26 @@ except ImportError:
     from distutils.core import setup
 
 
-setup(name = "clrsvsim",
-      version = "0.1.0",
-      description = "Color Genomics Structural Variant Simulator",
-      author = "Color Genomics",
-      author_email = "dev@color.com",
-      url = "https://github.com/ColorGenomics/clrsvsim",
-      packages = ["clrsvsim"],
-      install_requires=[
-        'cigar>=0.1.3',
-        'numpy>=1.10.1',
-        'preconditions>=0.1',
-        'pyfasta>=0.5.2',
-        'pysam>=0.10.0',
-      ],
-      tests_require=[
+setup(
+    name="clrsvsim",
+    version="0.1.0",
+    description="Color Genomics Structural Variant Simulator",
+    author="Color Genomics",
+    author_email="dev@color.com",
+    url="https://github.com/ColorGenomics/clrsvsim",
+    packages=["clrsvsim"],
+    install_requires=[
+        "cigar>=0.1.3",
+        "numpy>=1.10.1",
+        "preconditions>=0.1",
+        "pyfasta>=0.5.2",
+        "pysam>=0.10.0",
+    ],
+    tests_require=[
         # NOTE: `mock` is not actually needed in Python 3.
         # `unittest.mock` can be used instead.
-        'mock>=2.0.0',
-        'nose>=1.3.7',
-      ],
-      license = "Apache-2.0",
+        "mock>=2.0.0",
+        "nose>=1.3.7",
+    ],
+    license="Apache-2.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-import os
-
 try:
-  from setuptools import setup
-except:
-  from distutils.core import setup
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 setup(name = "clrsvsim",

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,14 @@ setup(name = "clrsvsim",
       packages = ["clrsvsim"],
       install_requires=[
         'cigar==0.1.3',
-        'mock==2.0.0',
-        'nose==1.3.7',
         'numpy==1.10.1',
         'preconditions==0.1',
         'pyfasta==0.5.2',
         'pysam==0.10.0',
+      ],
+      tests_require=[
+        'mock==2.0.0',
+        'nose==1.3.7',
       ],
       license = "Apache-2.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,22 +5,24 @@ except ImportError:
 
 
 setup(name = "clrsvsim",
-      version = "0.0.2",
+      version = "0.1.0",
       description = "Color Genomics Structural Variant Simulator",
       author = "Color Genomics",
       author_email = "dev@color.com",
       url = "https://github.com/ColorGenomics/clrsvsim",
       packages = ["clrsvsim"],
       install_requires=[
-        'cigar==0.1.3',
-        'numpy==1.10.1',
-        'preconditions==0.1',
-        'pyfasta==0.5.2',
-        'pysam==0.10.0',
+        'cigar>=0.1.3',
+        'numpy>=1.10.1',
+        'preconditions>=0.1',
+        'pyfasta>=0.5.2',
+        'pysam>=0.10.0',
       ],
       tests_require=[
-        'mock==2.0.0',
-        'nose==1.3.7',
+        # NOTE: `mock` is not actually needed in Python 3.
+        # `unittest.mock` can be used instead.
+        'mock>=2.0.0',
+        'nose>=1.3.7',
       ],
       license = "Apache-2.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ setup(
     name="clrsvsim",
     version="0.1.0",
     description="Color Genomics Structural Variant Simulator",
-    author="Color Genomics",
+    author="Color",
     author_email="dev@color.com",
-    url="https://github.com/ColorGenomics/clrsvsim",
+    url="https://github.com/color/clrsvsim",
     packages=["clrsvsim"],
     install_requires=[
         "cigar>=0.1.3",


### PR DESCRIPTION
This package should not require specific patch versions. Rather, it
should express the broadest range of possible versions that it supports.

In the current `setup.py`, we are very particular about which versions
must be used. Because of the specificity, installing `clrsvsim` makes
updating any other dependent libraries (e.g. `numpy`) quite difficult.

Modern dependency managers like `poetry` on `pipenv` will loudly
complain about dependency conflicts, making `clrsvism` a problematic
dependency.

Instead, we should just specify each of these as the *minimum* version
required. If there's some reason that the package does not support the
latest versions, then we can sort that out at a later time.