### PR TITLE
Use plain assertions instead of preconditions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ cigar==0.1.3
 mock==2.0.0
 nose==1.3.7
 numpy==1.10.1
-preconditions==0.1
 pyfasta==0.5.2
 pysam==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name="clrsvsim",
-    version="0.1.0",
+    version="0.1.1",
     description="Color Genomics Structural Variant Simulator",
     author="Color",
     author_email="dev@color.com",
@@ -15,7 +15,6 @@ setup(
     install_requires=[
         "cigar>=0.1.3",
         "numpy>=1.10.1",
-        "preconditions>=0.1",
         "pyfasta>=0.5.2",
         "pysam>=0.10.0",
     ],


### PR DESCRIPTION
The `preconditions` library provides a convenience for simple checking
of arguments via a lambda function, but we can achieve essentially the
same thing by just using `assert` statements in the body of the
function.

Additionally, correct a typo in one of the preconditions, where we
assert than `a[0] <= a[0]` (which should be true for just about any type
in Python, and is certainly true for integers).